### PR TITLE
Add select

### DIFF
--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -9,21 +9,15 @@ const Select = ({ label, value, onChange, children }) => {
   const displayedValue = getDisplayedValue(value, children);
 
   return (
-    <ContainingBlockWrapper>
-      <SelectWrapper>
-        {displayedValue}
-        <Icon id="chevron-down" style={{ display: "inline-block" }}></Icon>
-      </SelectWrapper>
+    <SelectWrapper>
+      <TextValueWrapper>{displayedValue}</TextValueWrapper>
+      <Icon id="chevron-down" size="24" strokeWidth="4"></Icon>
       <HiddenSelect value={value} onChange={onChange}>
         {children}
       </HiddenSelect>
-    </ContainingBlockWrapper>
+    </SelectWrapper>
   );
 };
-
-const ContainingBlockWrapper = styled.div`
-  position: relative;
-`;
 
 const HiddenSelect = styled.select`
   // Cover the entire parent area
@@ -37,8 +31,23 @@ const HiddenSelect = styled.select`
   opacity: 0;
 `;
 
-const SelectWrapper = styled.div`
+const TextValueWrapper = styled.div`
+  padding-right: 16px;
+`;
 
+const SelectWrapper = styled.div`
+  // Make it a containing block
+  position: relative;
+
+  background-color: ${COLORS.transparentGray15};
+  color: ${COLORS.gray700};
+
+  width: fit-content;
+  padding: 12px 8px 12px 16px;
+  border-radius: 8px;
+
+  display: flex;
+  align-items: center;
 `;
 
 export default Select;

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -9,10 +9,36 @@ const Select = ({ label, value, onChange, children }) => {
   const displayedValue = getDisplayedValue(value, children);
 
   return (
-    <select value={value} onChange={onChange}>
-      {children}
-    </select>
+    <ContainingBlockWrapper>
+      <SelectWrapper>
+        {displayedValue}
+        <Icon id="chevron-down" style={{ display: "inline-block" }}></Icon>
+      </SelectWrapper>
+      <HiddenSelect value={value} onChange={onChange}>
+        {children}
+      </HiddenSelect>
+    </ContainingBlockWrapper>
   );
 };
+
+const ContainingBlockWrapper = styled.div`
+  position: relative;
+`;
+
+const HiddenSelect = styled.select`
+  // Cover the entire parent area
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+
+  // Make the element invisible but still present (and responding to clicks)
+  opacity: 0;
+`;
+
+const SelectWrapper = styled.div`
+
+`;
 
 export default Select;

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -48,6 +48,10 @@ const SelectWrapper = styled.div`
 
   display: flex;
   align-items: center;
+
+  &:hover {
+    color: ${COLORS.black};
+  }
 `;
 
 export default Select;


### PR DESCRIPTION
Submission for [exercise 2, Select](https://github.com/VrsajkovIvan33/mini-component-library?tab=readme-ov-file#select).

I initially tried removing the default appearance of the native `<select>` element and adding the Icon beside it, with `display: inline-block`. That wasn't working as clicking on the icon wasn't triggering the selection.

Solution produced with the help of the hint suggesting to use `opacity: 0;` and putting the invisible `<select>` over the custom select.

Using Flexbox for centering the content, I wasn't able to do it with Flow layout.

Missing the focus styles.