### PR TITLE
Icon input

### DIFF
--- a/src/components/IconInput/IconInput.js
+++ b/src/components/IconInput/IconInput.js
@@ -45,10 +45,12 @@ const TextInput = styled.input.attrs({
   padding: 4px 4px 4px 24px;
 
   border: none;
+
   background-color: transparent;
+  color: ${COLORS.gray700};
 
   &::placeholder {
-      color: ${COLORS.gray500}
+      color: ${COLORS.gray500};
   }
 `;
 

--- a/src/components/IconInput/IconInput.js
+++ b/src/components/IconInput/IconInput.js
@@ -13,12 +13,50 @@ const IconInput = ({
   size,
   placeholder,
 }) => {
+  const SIZE_STYLES = {
+    small: {
+      borderWidth: 1,
+      iconSize: 16,
+      iconStrokeWidth: 1,
+      totalHeight: 24,
+      fontSize: 14,
+      lineHeight: 16,
+      padding: 4,
+      iconTextSpacing: 8,
+    },
+    large: {
+      borderWidth: 2,
+      iconSize: 24,
+      iconStrokeWidth: 2,
+      totalHeight: 36,
+      fontSize: 18,
+      lineHeight: 21,
+      padding: 6,
+      iconTextSpacing: 12,
+    }
+  }
+
+  const sizeStyle = SIZE_STYLES[size];
+
+  if (!sizeStyle) {
+    throw new Error(`Size not supported: ${size}`);
+  }
+
   return (
-    <InputWrapper style={{ "--width": width + "px" }}>
-      <IconWrapper>
-        <Icon id={icon} size={16} />
+    <InputWrapper style={{
+      "--height": sizeStyle.totalHeight + "px",
+      "--width": width + "px",
+      "--border-width": sizeStyle.borderWidth + "px"
+    }}
+    >
+      <IconWrapper style={{ "--icon-size": sizeStyle.iconSize + "px" }}>
+        <Icon id={icon} size={sizeStyle.iconSize} strokeWidth={sizeStyle.iconStrokeWidth} />
       </IconWrapper>
-      <TextInput placeholder={placeholder} />
+      <TextInput placeholder={placeholder} style={{
+        "--padding": (sizeStyle.padding + "px ").repeat(3) + (sizeStyle.iconSize + sizeStyle.iconTextSpacing) + "px",
+        "--font-size": (sizeStyle.fontSize / 16) + "rem",
+      }}
+      />
     </InputWrapper>
   )
 };
@@ -26,11 +64,12 @@ const IconInput = ({
 const IconWrapper = styled.div`
   position: absolute;
 
-  height: 16px;
+  height: var(--icon-size);
 
-  top: 4px;
-  bottom: 4px;
+  top: 0;
+  bottom: 0;
   left: 0;
+  margin: auto;
 `;
 
 const TextInput = styled.input.attrs({
@@ -42,13 +81,15 @@ const TextInput = styled.input.attrs({
   left: 0;
   right: 0;
 
-  padding: 4px 4px 4px 24px;
+  padding: var(--padding);
 
   border: none;
 
   background-color: transparent;
   color: ${COLORS.gray700};
+
   font-weight: 700;
+  font-size: var(--font-size);
 
   &::placeholder {
       color: ${COLORS.gray500};
@@ -59,10 +100,10 @@ const TextInput = styled.input.attrs({
 const InputWrapper = styled.div`
   position: relative;
 
-  height: 24px;
+  height: var(--height);
   width: var(--width);
 
-  border-bottom: 1px solid ${COLORS.black}
+  border-bottom: var(--border-width) solid ${COLORS.black}
 `;
 
 export default IconInput;

--- a/src/components/IconInput/IconInput.js
+++ b/src/components/IconInput/IconInput.js
@@ -20,7 +20,7 @@ const IconInput = ({
       <IconWrapper>
         <Icon id="search" size={16} />
       </IconWrapper>
-      <TextInput />
+      <TextInput placeholder={placeholder} />
     </InputWrapper>
   )
 };
@@ -55,6 +55,10 @@ const TextInput = styled.input.attrs({
 
   border: none;
   background-color: transparent;
+
+  &::placeholder {
+      color: ${COLORS.gray500}
+  }
 `;
 
 const InputWrapper = styled.div`

--- a/src/components/IconInput/IconInput.js
+++ b/src/components/IconInput/IconInput.js
@@ -48,9 +48,11 @@ const TextInput = styled.input.attrs({
 
   background-color: transparent;
   color: ${COLORS.gray700};
+  font-weight: 700;
 
   &::placeholder {
       color: ${COLORS.gray500};
+      font-weight: 400;
   }
 `;
 

--- a/src/components/IconInput/IconInput.js
+++ b/src/components/IconInput/IconInput.js
@@ -49,6 +49,7 @@ const IconInput = ({
       "--border-width": sizeStyle.borderWidth + "px"
     }}
     >
+      <VisuallyHidden>{label}</VisuallyHidden>
       <IconWrapper style={{ "--icon-size": sizeStyle.iconSize + "px" }}>
         <Icon id={icon} size={sizeStyle.iconSize} strokeWidth={sizeStyle.iconStrokeWidth} />
       </IconWrapper>

--- a/src/components/IconInput/IconInput.js
+++ b/src/components/IconInput/IconInput.js
@@ -13,10 +13,9 @@ const IconInput = ({
   size,
   placeholder,
 }) => {
-  // return <TextInput />;
+
   return (
-    <InputWrapper>
-      <Underline />
+    <InputWrapper style={{ "--width": width + "px" }}>
       <IconWrapper>
         <Icon id="search" size={16} />
       </IconWrapper>
@@ -25,17 +24,10 @@ const IconInput = ({
   )
 };
 
-const Underline = styled.div`
-  height: 24px;
-  background-color: transparent;
-  border-bottom: 1px solid ${COLORS.black}
-`
-
 const IconWrapper = styled.div`
   position: absolute;
 
   height: 16px;
-  width: 16px;
 
   top: 4px;
   bottom: 4px;
@@ -63,6 +55,11 @@ const TextInput = styled.input.attrs({
 
 const InputWrapper = styled.div`
   position: relative;
+
+  height: 24px;
+  width: var(--width);
+
+  border-bottom: 1px solid ${COLORS.black}
 `;
 
 export default IconInput;

--- a/src/components/IconInput/IconInput.js
+++ b/src/components/IconInput/IconInput.js
@@ -13,7 +13,52 @@ const IconInput = ({
   size,
   placeholder,
 }) => {
-  return 'TODO';
+  // return <TextInput />;
+  return (
+    <InputWrapper>
+      <Underline />
+      <IconWrapper>
+        <Icon id="search" size={16} />
+      </IconWrapper>
+      <TextInput />
+    </InputWrapper>
+  )
 };
+
+const Underline = styled.div`
+  height: 24px;
+  background-color: transparent;
+  border-bottom: 1px solid ${COLORS.black}
+`
+
+const IconWrapper = styled.div`
+  position: absolute;
+
+  height: 16px;
+  width: 16px;
+
+  top: 4px;
+  bottom: 4px;
+  left: 0;
+`;
+
+const TextInput = styled.input.attrs({
+  type: "text"
+})`
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+
+  padding: 4px 4px 4px 24px;
+
+  border: none;
+  background-color: transparent;
+`;
+
+const InputWrapper = styled.div`
+  position: relative;
+`;
 
 export default IconInput;

--- a/src/components/IconInput/IconInput.js
+++ b/src/components/IconInput/IconInput.js
@@ -13,11 +13,10 @@ const IconInput = ({
   size,
   placeholder,
 }) => {
-
   return (
     <InputWrapper style={{ "--width": width + "px" }}>
       <IconWrapper>
-        <Icon id="search" size={16} />
+        <Icon id={icon} size={16} />
       </IconWrapper>
       <TextInput placeholder={placeholder} />
     </InputWrapper>


### PR DESCRIPTION
Submission for [exercise 3, IconInput](https://github.com/css-for-js/mini-component-library?tab=readme-ov-file#iconinput).

- So many style changes when the size changes ...
- Using `position: absolute` on both IconWrapper and the input element:
  - IconWrapper: to center it, without using flexbox.
  - input: to have it appear in front of the Icon and make it focusable when the icon is clicked.
- The padding in the input element depends on the padding determined by size and the size of the icon

No hover or focus styles added :( 