### PR TITLE
Icon input corrections

### DIFF
--- a/src/components/IconInput/IconInput.js
+++ b/src/components/IconInput/IconInput.js
@@ -15,24 +15,18 @@ const IconInput = ({
 }) => {
   const SIZE_STYLES = {
     small: {
-      borderWidth: 1,
+      borderThickness: 1,
       iconSize: 16,
       iconStrokeWidth: 1,
-      totalHeight: 24,
-      fontSize: 14,
-      lineHeight: 16,
-      padding: 4,
-      iconTextSpacing: 8,
+      height: 24,
+      fontSize: 14
     },
     large: {
-      borderWidth: 2,
+      borderThickness: 2,
       iconSize: 24,
       iconStrokeWidth: 2,
-      totalHeight: 36,
-      fontSize: 18,
-      lineHeight: 21,
-      padding: 6,
-      iconTextSpacing: 12,
+      height: 36,
+      fontSize: 18
     }
   }
 
@@ -49,11 +43,10 @@ const IconInput = ({
         <Icon id={icon} size={sizeStyle.iconSize} strokeWidth={sizeStyle.iconStrokeWidth} />
       </IconWrapper>
       <TextInput placeholder={placeholder} style={{
-        "--padding": (sizeStyle.padding + "px ").repeat(3) + (sizeStyle.iconSize + sizeStyle.iconTextSpacing) + "px",
         "--font-size": (sizeStyle.fontSize / 16) + "rem",
-        "--height": sizeStyle.totalHeight + "px",
+        "--height": (sizeStyle.height / 16) + "rem",
         "--width": width + "px",
-        "--border-width": sizeStyle.borderWidth + "px"
+        "--border-thickness": sizeStyle.borderThickness + "px"
       }}
       />
     </InputWrapper>
@@ -63,12 +56,12 @@ const IconInput = ({
 const IconWrapper = styled.div`
   position: absolute;
 
-  height: var(--icon-size);
-
   top: 0;
   bottom: 0;
   left: 0;
   margin: auto;
+
+  height: var(--icon-size);
 
   pointer-events: none;
 `;
@@ -76,19 +69,18 @@ const IconWrapper = styled.div`
 const TextInput = styled.input.attrs({
   type: "text"
 })`
-  padding: var(--padding);
+  padding-left: var(--height);
 
   border: none;
-  border-bottom: var(--border-width) solid ${COLORS.black};
+  border-bottom: var(--border-thickness) solid ${COLORS.black};
 
-  background-color: transparent;
-  color: ${COLORS.gray700};
-
-  font-weight: 700;
-  font-size: var(--font-size);
+  color: inherit;
 
   height: var(--height);
   width: var(--width);
+
+  font-weight: 700;
+  font-size: var(--font-size);
 
   &::placeholder {
       color: ${COLORS.gray500};
@@ -98,6 +90,8 @@ const TextInput = styled.input.attrs({
 
 const InputWrapper = styled.div`
   position: relative;
+
+  color: ${COLORS.gray700};
 `;
 
 export default IconInput;

--- a/src/components/IconInput/IconInput.js
+++ b/src/components/IconInput/IconInput.js
@@ -83,8 +83,12 @@ const TextInput = styled.input.attrs({
   font-size: var(--font-size);
 
   &::placeholder {
-      color: ${COLORS.gray500};
-      font-weight: 400;
+    color: ${COLORS.gray500};
+    font-weight: 400;
+  }
+
+  &:focus {
+    outline-offset: 2px;
   }
 `;
 
@@ -92,6 +96,10 @@ const InputWrapper = styled.div`
   position: relative;
 
   color: ${COLORS.gray700};
+
+  &:hover {
+    color: ${COLORS.black};
+  }
 `;
 
 export default IconInput;

--- a/src/components/IconInput/IconInput.js
+++ b/src/components/IconInput/IconInput.js
@@ -43,12 +43,7 @@ const IconInput = ({
   }
 
   return (
-    <InputWrapper style={{
-      "--height": sizeStyle.totalHeight + "px",
-      "--width": width + "px",
-      "--border-width": sizeStyle.borderWidth + "px"
-    }}
-    >
+    <InputWrapper>
       <VisuallyHidden>{label}</VisuallyHidden>
       <IconWrapper style={{ "--icon-size": sizeStyle.iconSize + "px" }}>
         <Icon id={icon} size={sizeStyle.iconSize} strokeWidth={sizeStyle.iconStrokeWidth} />
@@ -56,6 +51,9 @@ const IconInput = ({
       <TextInput placeholder={placeholder} style={{
         "--padding": (sizeStyle.padding + "px ").repeat(3) + (sizeStyle.iconSize + sizeStyle.iconTextSpacing) + "px",
         "--font-size": (sizeStyle.fontSize / 16) + "rem",
+        "--height": sizeStyle.totalHeight + "px",
+        "--width": width + "px",
+        "--border-width": sizeStyle.borderWidth + "px"
       }}
       />
     </InputWrapper>
@@ -71,26 +69,26 @@ const IconWrapper = styled.div`
   bottom: 0;
   left: 0;
   margin: auto;
+
+  pointer-events: none;
 `;
 
 const TextInput = styled.input.attrs({
   type: "text"
 })`
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-
   padding: var(--padding);
 
   border: none;
+  border-bottom: var(--border-width) solid ${COLORS.black};
 
   background-color: transparent;
   color: ${COLORS.gray700};
 
   font-weight: 700;
   font-size: var(--font-size);
+
+  height: var(--height);
+  width: var(--width);
 
   &::placeholder {
       color: ${COLORS.gray500};
@@ -100,11 +98,6 @@ const TextInput = styled.input.attrs({
 
 const InputWrapper = styled.div`
   position: relative;
-
-  height: var(--height);
-  width: var(--width);
-
-  border-bottom: var(--border-width) solid ${COLORS.black}
 `;
 
 export default IconInput;


### PR DESCRIPTION
Changes made after watching the solution video for the third exercise for the workshop.

- Simplify markup and positional layout (no need for input to use `position: absolute;`).
- Simplify styles by removing unnecessary variables (like padding).
- Add focus and hover styles (now that we know to use `outline-offset`).